### PR TITLE
Fix issue with ignored index_settings. Closes #478

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/plugin/jdbc/client/BaseIngestTransportClient.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/jdbc/client/BaseIngestTransportClient.java
@@ -74,16 +74,14 @@ public abstract class BaseIngestTransportClient extends BaseTransportClient
         }
         CreateIndexRequestBuilder createIndexRequestBuilder =
                 new CreateIndexRequestBuilder(client.admin().indices()).setIndex(index);
-        Settings concreteSettings;
-        if (settings == null && getSettings() != null) {
-            concreteSettings = getSettings();
-        } else if (settings != null) {
+        Settings concreteSettings = null;
+        if (settings != null) {
             concreteSettings = settings;
-        } else {
-            concreteSettings = null;
+        } else if (getSettings() != null) {
+            concreteSettings = getSettings();
         }
         if (concreteSettings != null) {
-            createIndexRequestBuilder.setSettings(getSettings());
+            createIndexRequestBuilder.setSettings(concreteSettings);
         }
         if (mappings == null && getMappings() != null) {
             for (String type : getMappings().keySet()) {


### PR DESCRIPTION
@jprante It looks like the request settings were always based on `getSettings()` and never on the `settings` param. I've cleaned up the code, too, to make it more readable.