### PR TITLE
Fix #402 and #484 with an intermediate state : current_active_begin

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/plugin/jdbc/state/RiverState.java
+++ b/src/main/java/org/xbib/elasticsearch/plugin/jdbc/state/RiverState.java
@@ -62,6 +62,11 @@ public class RiverState implements Streamable, ToXContent, Comparable<RiverState
     private DateTime lastActiveBegin;
 
     /*
+     * The begin time of the current river activity
+     */
+    private DateTime currentActiveBegin;
+
+    /*
      * The time when the last river activity ended
      */
     private DateTime lastActiveEnd;
@@ -124,10 +129,30 @@ public class RiverState implements Streamable, ToXContent, Comparable<RiverState
     }
 
     /**
+     * Set the current river begin DateTime. It will be used to
+     * update lastActiveBegin after the run being done
+     * 
+     * @param begin
+     *            when the current river activity began
+     * @return this state
+     */
+    public RiverState setCurrentActive(DateTime begin) {
+        this.currentActiveBegin = begin;
+        return this;
+    }
+
+    /**
      * @return the begin of the last river activity
      */
     public DateTime getLastActiveBegin() {
         return lastActiveBegin;
+    }
+
+    /**
+     * @return the begin of the current river activity
+     */
+    public DateTime getCurrentActiveBegin() {
+        return currentActiveBegin;
     }
 
     /**
@@ -250,6 +275,7 @@ public class RiverState implements Streamable, ToXContent, Comparable<RiverState
                 .field("type", type)
                 .field("started", getStarted())
                 .field("last_active_begin", getLastActiveBegin())
+                .field("current_active_begin", getCurrentActiveBegin())
                 .field("last_active_end", getLastActiveEnd())
                 .field("map", map);
         builder.endObject();
@@ -266,6 +292,9 @@ public class RiverState implements Streamable, ToXContent, Comparable<RiverState
         }
         if (in.readBoolean()) {
             this.lastActiveBegin = new DateTime(in.readLong());
+        }
+        if (in.readBoolean()) {
+            this.currentActiveBegin = new DateTime(in.readLong());
         }
         if (in.readBoolean()) {
             this.lastActiveEnd = new DateTime(in.readLong());
@@ -287,6 +316,13 @@ public class RiverState implements Streamable, ToXContent, Comparable<RiverState
             out.writeBoolean(true);
             out.writeLong(lastActiveBegin.getMillis());
         } else {
+            out.writeBoolean(false);
+        }
+        if (currentActiveBegin != null) {
+            out.writeBoolean(true);
+            out.writeLong(currentActiveBegin.getMillis());
+        }
+        else {
             out.writeBoolean(false);
         }
         if (lastActiveEnd != null) {

--- a/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/simple/SimpleRiverFlow.java
+++ b/src/main/java/org/xbib/elasticsearch/river/jdbc/strategy/simple/SimpleRiverFlow.java
@@ -189,7 +189,10 @@ public class SimpleRiverFlow<RC extends RiverContext> implements RiverFlow<RC> {
         logger.debug("before fetch: created source = {}, mouth = {}, context = {}",
                 riverSource, riverMouth, riverContext);
         Integer counter = riverState.getCounter() + 1;
-        riverContext.setRiverState(riverState.setCounter(counter).setLastActive(new DateTime(), null));
+        DateTime currentTime = riverContext.getRiverState().getCurrentActiveBegin();
+        riverContext.setRiverState(riverState.setCounter(counter)
+                .setLastActive(currentTime != null ? currentTime : new DateTime(0), null)
+                .setCurrentActive(new DateTime()));
         PostRiverStateRequestBuilder postRiverStateRequestBuilder = new PostRiverStateRequestBuilder(client.admin().cluster())
                 .setRiverName(riverName.getName())
                 .setRiverType(riverName.getType())
@@ -259,7 +262,7 @@ public class SimpleRiverFlow<RC extends RiverContext> implements RiverFlow<RC> {
         }
         // set activity
         RiverState riverState = riverContext.getRiverState()
-                .setLastActive(riverContext.getRiverState().getLastActiveBegin(), new DateTime());
+                .setLastActive(riverContext.getRiverState().getCurrentActiveBegin(), new DateTime());
         PostRiverStateRequestBuilder postRiverStateRequestBuilder = new PostRiverStateRequestBuilder(client.admin().cluster())
                 .setRiverName(riverName.getName())
                 .setRiverType(riverName.getType())


### PR DESCRIPTION
The intermediate *current_active_begin* is provided as a new RiverState property.

**beforeFetch()** uses it to set the *last_active_begin* state when the River instanciates a new run. If *current_active_begin*  is null then we set the *last_active_begin* to epoch(0) so that the first run will apply the query statement over the entire table. *current_active_begin* is set just after *last_active_begin* so that on the next run, *current_active_begin* won't be null.

Since *setLastActive()* is called from *afterFetch()*, we set the *last_active_begin* to the *current_active_begin* there too.
